### PR TITLE
Support stripping initial UTF-8 BOM header

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -11,6 +11,31 @@ use futures_util::{stream::MapOk, Stream, TryStreamExt};
 use http_body::{Body, Frame};
 use http_body_util::{BodyDataStream, StreamBody};
 
+#[derive(Debug)]
+enum BomHeaderState {
+    Parsing(Vec<u8>),
+    Consumed,
+}
+
+const BOM_HEADER: &[u8] = b"\xEF\xBB\xBF";
+
+// Try to consume the BOM header from the given bytes.
+// If the BOM header is found, return the remaining bytes, otherwise return the origin buffer.
+// Return `None` if we cannot determine whether the BOM header is present.
+fn try_consume_bom_header(buf: &[u8]) -> Option<&[u8]> {
+    if buf.len() < BOM_HEADER.len() {
+        if BOM_HEADER.starts_with(buf) {
+            None
+        } else {
+            Some(buf)
+        }
+    } else if buf.starts_with(BOM_HEADER) {
+        Some(&buf[BOM_HEADER.len()..])
+    } else {
+        Some(buf)
+    }
+}
+
 pin_project_lite::pin_project! {
     pub struct SseStream<B: Body> {
         #[pin]
@@ -18,6 +43,7 @@ pin_project_lite::pin_project! {
         parsed: VecDeque<Sse>,
         current: Option<Sse>,
         unfinished_line: Vec<u8>,
+        bom_header_state: BomHeaderState,
     }
 }
 
@@ -40,6 +66,7 @@ where
             parsed: VecDeque::new(),
             current: None,
             unfinished_line: Vec::new(),
+            bom_header_state: BomHeaderState::Parsing(Vec::new()),
         }
     }
 }
@@ -52,6 +79,7 @@ impl<B: Body> SseStream<B> {
             parsed: VecDeque::new(),
             current: None,
             unfinished_line: Vec::new(),
+            bom_header_state: BomHeaderState::Parsing(Vec::new()),
         }
     }
 }
@@ -134,7 +162,20 @@ where
         let next_data = ready!(this.body.poll_next(cx));
         match next_data {
             Some(Ok(data)) => {
-                let chunk = data.chunk();
+                let stripped_vec = if let BomHeaderState::Parsing(buf) = this.bom_header_state {
+                    buf.extend_from_slice(data.chunk());
+                    if let Some(stripped) = try_consume_bom_header(buf) {
+                        let stripped_vec = stripped.to_vec();
+                        *this.bom_header_state = BomHeaderState::Consumed;
+                        Some(stripped_vec)
+                    } else {
+                        return self.poll_next(cx);
+                    }
+                } else {
+                    None
+                };
+
+                let chunk = stripped_vec.as_deref().unwrap_or(data.chunk());
 
                 if chunk.is_empty() {
                     return self.poll_next(cx);

--- a/tests/test_bytes_parse.rs
+++ b/tests/test_bytes_parse.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use futures_util::StreamExt;
-use http_body_util::Full;
+use http_body::Frame;
+use http_body_util::{Full, StreamBody};
 
 #[tokio::test]
 async fn test_bytes_parse() {
@@ -11,4 +12,33 @@ async fn test_bytes_parse() {
     while let Some(sse) = sse_body.next().await {
         println!("{:?}", sse.unwrap());
     }
+}
+
+#[tokio::test]
+async fn test_bom_header_at_start() {
+    let sse_data = b"\xEF\xBB\xBFdata: hello\n\n";
+    let body = Full::<Bytes>::from(sse_data.to_vec());
+    let mut sse_body = sse_stream::SseStream::new(body);
+
+    let sse = sse_body.next().await.expect("Should have one SSE event").unwrap();
+    assert_eq!(sse.data, Some("hello".to_string()));
+}
+
+#[tokio::test]
+async fn test_bom_split_across_chunks() {
+    let chunk1 = Bytes::from(vec![0xEF]);
+    let chunk2 = Bytes::from(vec![0xBB, 0xBF, b'd', b'a', b't', b'a', b':', b' ', b'h', b'e', b'l', b'l', b'o', b'\n', b'\n']);
+
+    let body = {
+        let stream = futures_util::stream::iter(
+            [chunk1, chunk2]
+                .into_iter()
+                .map(|chunk| Ok::<_, std::convert::Infallible>(Frame::data(chunk)))
+        );
+        StreamBody::new(stream)
+    };
+    let mut sse_body = sse_stream::SseStream::new(body);
+
+    let sse = sse_body.next().await.expect("Should have one SSE event").unwrap();
+    assert_eq!(sse.data, Some("hello".to_string()));
 }

--- a/tests/test_bytes_parse.rs
+++ b/tests/test_bytes_parse.rs
@@ -26,8 +26,8 @@ async fn test_bom_header_at_start() {
 
 #[tokio::test]
 async fn test_bom_split_across_chunks() {
-    let chunk1 = Bytes::from(vec![0xEF]);
-    let chunk2 = Bytes::from(vec![0xBB, 0xBF, b'd', b'a', b't', b'a', b':', b' ', b'h', b'e', b'l', b'l', b'o', b'\n', b'\n']);
+    let chunk1 = Bytes::from_static(b"\xEF");
+    let chunk2 = Bytes::from_static(b"\xBB\xBFdata: hello\n\n");
 
     let body = {
         let stream = futures_util::stream::iter(


### PR DESCRIPTION
Similar to [this pr](https://github.com/launchdarkly/rust-eventsource-client/pull/114), according to the [SSE standard](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream), a UTF-8 BOM header may appear at the beginning of the message, so I support this by introducing a state machine (`BomHeaderState`) in `SseStream`. It buffers the initial data from the first message, strips BOM header if it exists, and passes the following data to the downstream parser.

This may introduce an extra memory allocation at the beginning of the connection, but for the rest of the stream, the overhead is negligible.