### PR TITLE
Bug fix & More spec compliance

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::VecDeque,
-    io::BufRead,
     mem,
     num::ParseIntError,
     str::Utf8Error,
@@ -270,14 +269,15 @@ where
                         continue;
                     }
                     // find comma
-                    let comma_index=if let Some(comma_index) = line.iter().position(|b| *b == b':'){
-                        comma_index
-                    } else {
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!(?line, "invalid line, missing `:`");
-                        // The line without comma will be regarded as the field name
-                        line.len()
-                    };
+                    let comma_index =
+                        if let Some(comma_index) = line.iter().position(|b| *b == b':') {
+                            comma_index
+                        } else {
+                            #[cfg(feature = "tracing")]
+                            tracing::warn!(?line, "invalid line, missing `:`");
+                            // The line without comma will be regarded as the field name
+                            line.len()
+                        };
                     let field_name = &line[..comma_index];
                     let field_value = if line.len() > comma_index + 1 {
                         let field_value = &line[comma_index + 1..];
@@ -343,7 +343,7 @@ where
                                 .trim_ascii();
                             let retry_parse_res =
                                 retry_value.parse::<u64>().map_err(Error::IntParse);
-                            if let Ok(retry_value)=retry_parse_res{
+                            if let Ok(retry_value) = retry_parse_res {
                                 if let Some(Sse { retry, .. }) = this.current.as_mut() {
                                     // If more than one line has same field name, later one will replace previous one
                                     retry.replace(retry_value);
@@ -353,10 +353,14 @@ where
                                         ..Default::default()
                                     });
                                 }
-                            }else{
+                            } else {
                                 #[cfg(feature = "tracing")]
                                 if tracing::enabled!(tracing::Level::WARN) {
-                                    tracing::warn!(line = ?_line, "invalid retry: non-int field {}",retry_value);
+                                    tracing::warn!(
+                                        ?line,
+                                        "invalid retry: non-int field {}",
+                                        retry_value
+                                    );
                                 }
                             }
                         }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -271,15 +271,11 @@ where
                         continue;
                     }
                     // find comma
-                    let comma_index =
-                        if let Some(comma_index) = line.iter().position(|b| *b == b':') {
-                            comma_index
-                        } else {
-                            #[cfg(feature = "tracing")]
-                            tracing::warn!(?line, "invalid line, missing `:`");
-                            // The line without comma will be regarded as the field name
-                            line.len()
-                        };
+                    let Some(comma_index) = line.iter().position(|b| *b == b':') else {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(?line, "invalid line, missing `:`");
+                        return Poll::Ready(Some(Err(Error::InvalidLine)));
+                    };
                     let field_name = &line[..comma_index];
                     let field_value = if line.len() > comma_index + 1 {
                         let field_value = &line[comma_index + 1..];
@@ -315,8 +311,11 @@ where
                             let event_value =
                                 std::str::from_utf8(field_value).map_err(Error::Utf8Parse)?;
                             if let Some(Sse { event, .. }) = this.current.as_mut() {
-                                // If more than one line has same field name, later one will replace previous one
-                                event.replace(event_value.to_owned());
+                                if event.is_some() {
+                                    return Poll::Ready(Some(Err(Error::DuplicatedEventLine)));
+                                } else {
+                                    event.replace(event_value.to_owned());
+                                }
                             } else {
                                 this.current.replace(Sse {
                                     event: Some(event_value.to_owned()),
@@ -325,11 +324,24 @@ where
                             }
                         }
                         b"id" => {
+                            // Per spec: if the id field value contains U+0000 NULL,
+                            // the entire field MUST be ignored.
+                            if field_value.contains(&0u8) {
+                                #[cfg(feature = "tracing")]
+                                tracing::warn!(
+                                    ?line,
+                                    "id field contains NULL byte, ignoring per spec"
+                                );
+                                continue;
+                            }
                             let id_value =
                                 std::str::from_utf8(field_value).map_err(Error::Utf8Parse)?;
                             if let Some(Sse { id, .. }) = this.current.as_mut() {
-                                // If more than one line has same field name, later one will replace previous one
-                                id.replace(id_value.to_owned());
+                                if id.is_some() {
+                                    return Poll::Ready(Some(Err(Error::DuplicatedIdLine)));
+                                } else {
+                                    id.replace(id_value.to_owned());
+                                }
                             } else {
                                 this.current.replace(Sse {
                                     id: Some(id_value.to_owned()),
@@ -341,27 +353,19 @@ where
                             let retry_value = std::str::from_utf8(field_value)
                                 .map_err(Error::Utf8Parse)?
                                 .trim_ascii();
-                            let retry_parse_res =
-                                retry_value.parse::<u64>().map_err(Error::IntParse);
-                            if let Ok(retry_value) = retry_parse_res {
-                                if let Some(Sse { retry, .. }) = this.current.as_mut() {
-                                    // If more than one line has same field name, later one will replace previous one
-                                    retry.replace(retry_value);
+                            let retry_value =
+                                retry_value.parse::<u64>().map_err(Error::IntParse)?;
+                            if let Some(Sse { retry, .. }) = this.current.as_mut() {
+                                if retry.is_some() {
+                                    return Poll::Ready(Some(Err(Error::DuplicatedRetry)));
                                 } else {
-                                    this.current.replace(Sse {
-                                        retry: Some(retry_value),
-                                        ..Default::default()
-                                    });
+                                    retry.replace(retry_value);
                                 }
                             } else {
-                                #[cfg(feature = "tracing")]
-                                if tracing::enabled!(tracing::Level::WARN) {
-                                    tracing::warn!(
-                                        ?line,
-                                        "invalid retry: non-int field {}",
-                                        retry_value
-                                    );
-                                }
+                                this.current.replace(Sse {
+                                    retry: Some(retry_value),
+                                    ..Default::default()
+                                });
                             }
                         }
                         b"" => {
@@ -378,7 +382,7 @@ where
                             if tracing::enabled!(tracing::Level::WARN) {
                                 tracing::warn!(line = ?_line, "invalid line: unknown field");
                             }
-                            // Invalid line will be ignored.
+                            return Poll::Ready(Some(Err(Error::InvalidLine)));
                         }
                     }
                 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,5 +1,7 @@
 use std::{
     collections::VecDeque,
+    io::BufRead,
+    mem,
     num::ParseIntError,
     str::Utf8Error,
     task::{ready, Context, Poll},
@@ -36,13 +38,92 @@ fn try_consume_bom_header(buf: &[u8]) -> Option<&[u8]> {
     }
 }
 
+#[derive(Debug)]
+enum UnfinishedLineState {
+    // A `\r` was received before, so next `\n` should be ignored.
+    MayTrailingNewline,
+    // An unfinished line is found.
+    Unfinished(Vec<u8>),
+}
+
+struct SseLines {
+    buf: Vec<u8>,
+    pos: usize,
+    finished: bool,
+}
+
+impl SseLines {
+    pub fn next_line(&mut self) -> Option<&[u8]> {
+        let mut slice_iter = self.buf[self.pos..].iter().enumerate();
+        let new_line = loop {
+            if let Some((idx, &c)) = slice_iter.next() {
+                if c == b'\n' {
+                    break Some((idx, "\n"));
+                }
+                if c == b'\r' {
+                    if let Some((_, &next_c)) = slice_iter.next() {
+                        if next_c == b'\n' {
+                            break Some((idx, "\r\n"));
+                        }
+                    }
+                    break Some((idx, "\r"));
+                }
+            } else {
+                break None;
+            }
+        };
+        if let Some((idx, lb)) = new_line {
+            let pure_line = &self.buf[self.pos..self.pos + idx];
+            self.pos += idx + lb.len();
+            return Some(pure_line);
+        } else {
+            self.finished = true;
+            return None;
+        }
+    }
+
+    pub fn finish(self) -> UnfinishedLineState {
+        if self.finished {
+            if self.buf.last() == Some(&b'\r') {
+                return UnfinishedLineState::MayTrailingNewline;
+            } else {
+                return UnfinishedLineState::Unfinished(self.buf[self.pos..].to_vec());
+            }
+        } else {
+            panic!("SseLines::finish() called before all lines are parsed");
+        }
+    }
+}
+
+fn parse_lines_with_state(state: &mut UnfinishedLineState, buf: &[u8]) -> SseLines {
+    match state {
+        UnfinishedLineState::MayTrailingNewline => {
+            let buf_vec = buf.strip_prefix(b"\n").unwrap_or(buf).to_vec();
+            SseLines {
+                buf: buf_vec,
+                pos: 0,
+                finished: false,
+            }
+        }
+        UnfinishedLineState::Unfinished(line) => {
+            let mut remains = mem::take(line);
+            remains.extend_from_slice(buf);
+            SseLines {
+                buf: remains,
+                pos: 0,
+                finished: false,
+            }
+        }
+    }
+}
+
 pin_project_lite::pin_project! {
     pub struct SseStream<B: Body> {
         #[pin]
         body: BodyDataStream<B>,
         parsed: VecDeque<Sse>,
         current: Option<Sse>,
-        unfinished_line: Vec<u8>,
+        unfinished_line_state: UnfinishedLineState,
         bom_header_state: BomHeaderState,
     }
 }
@@ -65,7 +146,7 @@ where
             body: BodyDataStream::new(body),
             parsed: VecDeque::new(),
             current: None,
-            unfinished_line: Vec::new(),
+            unfinished_line_state: UnfinishedLineState::Unfinished(Vec::new()),
             bom_header_state: BomHeaderState::Parsing(Vec::new()),
         }
     }
@@ -78,7 +159,7 @@ impl<B: Body> SseStream<B> {
             body: BodyDataStream::new(body),
             parsed: VecDeque::new(),
             current: None,
-            unfinished_line: Vec::new(),
+            unfinished_line_state: UnfinishedLineState::Unfinished(Vec::new()),
             bom_header_state: BomHeaderState::Parsing(Vec::new()),
         }
     }
@@ -180,29 +261,8 @@ where
                 if chunk.is_empty() {
                     return self.poll_next(cx);
                 }
-                let mut lines = chunk.chunk_by(|maybe_nl, _| *maybe_nl != b'\n');
-                let first_line = lines.next().expect("frame is empty");
-                let mut new_unfinished_line = Vec::new();
-                let first_line = if !this.unfinished_line.is_empty() {
-                    this.unfinished_line.extend(first_line);
-                    std::mem::swap(&mut new_unfinished_line, this.unfinished_line);
-                    new_unfinished_line.as_ref()
-                } else {
-                    first_line
-                };
-                let mut lines = std::iter::once(first_line).chain(lines);
-                *this.unfinished_line = loop {
-                    let Some(line) = lines.next() else {
-                        break Vec::new();
-                    };
-                    let line = if line.ends_with(b"\r\n") {
-                        &line[..line.len() - 2]
-                    } else if line.ends_with(b"\n") || line.ends_with(b"\r") {
-                        &line[..line.len() - 1]
-                    } else {
-                        break line.to_vec();
-                    };
-
+                let mut line_iter = parse_lines_with_state(this.unfinished_line_state, chunk);
+                while let Some(line) = line_iter.next_line() {
                     if line.is_empty() {
                         if let Some(sse) = this.current.take() {
                             this.parsed.push_back(sse);
@@ -316,7 +376,9 @@ where
                             return Poll::Ready(Some(Err(Error::InvalidLine)));
                         }
                     }
-                };
+                }
+                let mut new_state = line_iter.finish();
+                mem::swap(this.unfinished_line_state, &mut new_state);
                 self.poll_next(cx)
             }
             Some(Err(e)) => Poll::Ready(Some(Err(Error::Body(Box::new(e))))),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -74,19 +74,19 @@ impl SseLines {
         if let Some((idx, lb)) = new_line {
             let pure_line = &self.buf[self.pos..self.pos + idx];
             self.pos += idx + lb.len();
-            return Some(pure_line);
+            Some(pure_line)
         } else {
             self.finished = true;
-            return None;
+            None
         }
     }
 
     pub fn finish(self) -> UnfinishedLineState {
         if self.finished {
             if self.buf.last() == Some(&b'\r') {
-                return UnfinishedLineState::MayTrailingNewline;
+                UnfinishedLineState::MayTrailingNewline
             } else {
-                return UnfinishedLineState::Unfinished(self.buf[self.pos..].to_vec());
+                UnfinishedLineState::Unfinished(self.buf[self.pos..].to_vec())
             }
         } else {
             panic!("SseLines::finish() called before all lines are parsed");
@@ -241,9 +241,11 @@ where
         }
         let next_data = ready!(this.body.poll_next(cx));
         match next_data {
-            Some(Ok(data)) => {
+            Some(Ok(mut data)) => {
+                // Buf might be incontinue structure, like `rope`, so we have to read all of it's remaining
+                let data_bytes = data.copy_to_bytes(data.remaining());
                 let stripped_vec = if let BomHeaderState::Parsing(buf) = this.bom_header_state {
-                    buf.extend_from_slice(data.chunk());
+                    buf.extend_from_slice(&data_bytes);
                     if let Some(stripped) = try_consume_bom_header(buf) {
                         let stripped_vec = stripped.to_vec();
                         *this.bom_header_state = BomHeaderState::Consumed;
@@ -255,7 +257,7 @@ where
                     None
                 };
 
-                let chunk = stripped_vec.as_deref().unwrap_or(data.chunk());
+                let chunk = stripped_vec.as_deref().unwrap_or(&data_bytes);
 
                 if chunk.is_empty() {
                     return self.poll_next(cx);

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -306,10 +306,8 @@ where
                                 }
                             } else {
                                 this.current.replace(Sse {
-                                    event: None,
                                     data: Some(data_line.to_owned()),
-                                    id: None,
-                                    retry: None,
+                                    ..Default::default()
                                 });
                             }
                         }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -270,10 +270,13 @@ where
                         continue;
                     }
                     // find comma
-                    let Some(comma_index) = line.iter().position(|b| *b == b':') else {
+                    let comma_index=if let Some(comma_index) = line.iter().position(|b| *b == b':'){
+                        comma_index
+                    } else {
                         #[cfg(feature = "tracing")]
                         tracing::warn!(?line, "invalid line, missing `:`");
-                        return Poll::Ready(Some(Err(Error::InvalidLine)));
+                        // The line without comma will be regarded as the field name
+                        line.len()
                     };
                     let field_name = &line[..comma_index];
                     let field_value = if line.len() > comma_index + 1 {
@@ -312,11 +315,8 @@ where
                             let event_value =
                                 std::str::from_utf8(field_value).map_err(Error::Utf8Parse)?;
                             if let Some(Sse { event, .. }) = this.current.as_mut() {
-                                if event.is_some() {
-                                    return Poll::Ready(Some(Err(Error::DuplicatedEventLine)));
-                                } else {
-                                    event.replace(event_value.to_owned());
-                                }
+                                // If more than one line has same field name, later one will replace previous one
+                                event.replace(event_value.to_owned());
                             } else {
                                 this.current.replace(Sse {
                                     event: Some(event_value.to_owned()),
@@ -328,11 +328,8 @@ where
                             let id_value =
                                 std::str::from_utf8(field_value).map_err(Error::Utf8Parse)?;
                             if let Some(Sse { id, .. }) = this.current.as_mut() {
-                                if id.is_some() {
-                                    return Poll::Ready(Some(Err(Error::DuplicatedIdLine)));
-                                } else {
-                                    id.replace(id_value.to_owned());
-                                }
+                                // If more than one line has same field name, later one will replace previous one
+                                id.replace(id_value.to_owned());
                             } else {
                                 this.current.replace(Sse {
                                     id: Some(id_value.to_owned()),
@@ -344,19 +341,23 @@ where
                             let retry_value = std::str::from_utf8(field_value)
                                 .map_err(Error::Utf8Parse)?
                                 .trim_ascii();
-                            let retry_value =
-                                retry_value.parse::<u64>().map_err(Error::IntParse)?;
-                            if let Some(Sse { retry, .. }) = this.current.as_mut() {
-                                if retry.is_some() {
-                                    return Poll::Ready(Some(Err(Error::DuplicatedRetry)));
-                                } else {
+                            let retry_parse_res =
+                                retry_value.parse::<u64>().map_err(Error::IntParse);
+                            if let Ok(retry_value)=retry_parse_res{
+                                if let Some(Sse { retry, .. }) = this.current.as_mut() {
+                                    // If more than one line has same field name, later one will replace previous one
                                     retry.replace(retry_value);
+                                } else {
+                                    this.current.replace(Sse {
+                                        retry: Some(retry_value),
+                                        ..Default::default()
+                                    });
                                 }
-                            } else {
-                                this.current.replace(Sse {
-                                    retry: Some(retry_value),
-                                    ..Default::default()
-                                });
+                            }else{
+                                #[cfg(feature = "tracing")]
+                                if tracing::enabled!(tracing::Level::WARN) {
+                                    tracing::warn!(line = ?_line, "invalid retry: non-int field {}",retry_value);
+                                }
                             }
                         }
                         b"" => {
@@ -373,7 +374,7 @@ where
                             if tracing::enabled!(tracing::Level::WARN) {
                                 tracing::warn!(line = ?_line, "invalid line: unknown field");
                             }
-                            return Poll::Ready(Some(Err(Error::InvalidLine)));
+                            // Invalid line will be ignored.
                         }
                     }
                 }
@@ -383,11 +384,8 @@ where
             }
             Some(Err(e)) => Poll::Ready(Some(Err(Error::Body(Box::new(e))))),
             None => {
-                if let Some(sse) = this.current.take() {
-                    Poll::Ready(Some(Ok(sse)))
-                } else {
-                    Poll::Ready(None)
-                }
+                // When data stream terminated without empty line, we should discard last incomplate message.
+                Poll::Ready(None)
             }
         }
     }

--- a/tests/test_bytes_parse.rs
+++ b/tests/test_bytes_parse.rs
@@ -4,19 +4,6 @@ use http_body::Frame;
 use http_body_util::{Full, StreamBody};
 use sse_stream::{Sse, SseStream};
 
-// =====================================================================
-// Bug exposure: `Buf::chunk()` only returns the *first contiguous* slice.
-//
-// `SseStream` reads each frame via `data.chunk()`. The `Buf` contract,
-// however, only requires `chunk()` to return *some* prefix of the
-// remaining bytes — not all of them. For multi-segment `Buf`
-// implementations (e.g. the result of `Bytes::chain`), this silently
-// drops every byte after the first segment.
-// =====================================================================
-
-/// A body that emits a single frame whose `Data` is a multi-segment
-/// `Buf` (`bytes::buf::Chain`). `chunk()` on such a value returns only
-/// the first segment, so any naive `data.chunk()` reader will lose data.
 struct ChainedFrameBody {
     sent: bool,
     first: &'static [u8],

--- a/tests/test_bytes_parse.rs
+++ b/tests/test_bytes_parse.rs
@@ -20,25 +20,35 @@ async fn test_bom_header_at_start() {
     let body = Full::<Bytes>::from(sse_data.to_vec());
     let mut sse_body = sse_stream::SseStream::new(body);
 
-    let sse = sse_body.next().await.expect("Should have one SSE event").unwrap();
+    let sse = sse_body
+        .next()
+        .await
+        .expect("Should have one SSE event")
+        .unwrap();
     assert_eq!(sse.data, Some("hello".to_string()));
 }
 
 #[tokio::test]
 async fn test_bom_split_across_chunks() {
     let chunk1 = Bytes::from(vec![0xEF]);
-    let chunk2 = Bytes::from(vec![0xBB, 0xBF, b'd', b'a', b't', b'a', b':', b' ', b'h', b'e', b'l', b'l', b'o', b'\n', b'\n']);
+    let chunk2 = Bytes::from(vec![
+        0xBB, 0xBF, b'd', b'a', b't', b'a', b':', b' ', b'h', b'e', b'l', b'l', b'o', b'\n', b'\n',
+    ]);
 
     let body = {
         let stream = futures_util::stream::iter(
             [chunk1, chunk2]
                 .into_iter()
-                .map(|chunk| Ok::<_, std::convert::Infallible>(Frame::data(chunk)))
+                .map(|chunk| Ok::<_, std::convert::Infallible>(Frame::data(chunk))),
         );
         StreamBody::new(stream)
     };
     let mut sse_body = sse_stream::SseStream::new(body);
 
-    let sse = sse_body.next().await.expect("Should have one SSE event").unwrap();
+    let sse = sse_body
+        .next()
+        .await
+        .expect("Should have one SSE event")
+        .unwrap();
     assert_eq!(sse.data, Some("hello".to_string()));
 }

--- a/tests/test_bytes_parse.rs
+++ b/tests/test_bytes_parse.rs
@@ -15,9 +15,11 @@ async fn collect_from_full(data: &[u8]) -> Vec<Sse> {
 }
 
 async fn collect_from_chunks(chunks: Vec<&'static [u8]>) -> Vec<Sse> {
-    let stream = futures_util::stream::iter(chunks.into_iter().map(|c| {
-        Ok::<_, std::convert::Infallible>(Frame::data(Bytes::from_static(c)))
-    }));
+    let stream = futures_util::stream::iter(
+        chunks
+            .into_iter()
+            .map(|c| Ok::<_, std::convert::Infallible>(Frame::data(Bytes::from_static(c)))),
+    );
     let body = StreamBody::new(stream);
     let mut sse_body = SseStream::new(body);
     let mut out = Vec::new();
@@ -25,6 +27,15 @@ async fn collect_from_chunks(chunks: Vec<&'static [u8]>) -> Vec<Sse> {
         out.push(sse.expect("parse error"));
     }
     out
+}
+
+fn data_only(s: &str) -> Sse {
+    Sse {
+        event: None,
+        data: Some(s.to_owned()),
+        id: None,
+        retry: None,
+    }
 }
 
 #[tokio::test]
@@ -50,6 +61,254 @@ async fn test_bom_header_at_start() {
         .expect("Should have one SSE event")
         .unwrap();
     assert_eq!(sse.data, Some("hello".to_string()));
+}
+
+// =====================================================================
+// Line-break handling corner cases
+// =====================================================================
+
+/// `\n` line break only.
+#[tokio::test]
+async fn test_line_break_lf_only() {
+    let out = collect_from_full(b"data: a\ndata: b\n\n").await;
+    assert_eq!(out, vec![data_only("a\nb")]);
+}
+
+/// `\r\n` line break (Windows-style).
+#[tokio::test]
+async fn test_line_break_crlf() {
+    let out = collect_from_full(b"data: a\r\ndata: b\r\n\r\n").await;
+    assert_eq!(out, vec![data_only("a\nb")]);
+}
+
+/// Bare `\r` line break (legacy Mac style).
+#[tokio::test]
+async fn test_line_break_cr_only() {
+    let out = collect_from_full(b"data: a\rdata: b\r\r").await;
+    assert_eq!(out, vec![data_only("a\nb")]);
+}
+
+/// Mixed line breaks within the same payload.
+#[tokio::test]
+async fn test_line_break_mixed() {
+    // `\n`, `\r`, and `\r\n` interleaved.
+    let payload: &[u8] = b"data: one\r\ndata: two\rdata: three\n\r\n";
+    let out = collect_from_full(payload).await;
+    assert_eq!(out, vec![data_only("one\ntwo\nthree")]);
+}
+
+/// `\r` at the END of one chunk and `\n` at the START of the next chunk
+/// must be treated as ONE `\r\n` line break, not two empty separator lines.
+/// This is the central bug `MayTrailingNewline` is meant to fix.
+#[tokio::test]
+async fn test_cr_lf_split_across_chunks() {
+    // Original payload:  "data: hello\r\ndata: world\n\n"
+    // Split:             "data: hello\r"  +  "\ndata: world\n\n"
+    let out = collect_from_chunks(vec![b"data: hello\r", b"\ndata: world\n\n"]).await;
+    assert_eq!(out, vec![data_only("hello\nworld")]);
+}
+
+/// Trailing `\r` followed by a non-`\n` char in the next chunk should
+/// produce TWO line breaks (the `\r` alone, then a fresh line).
+#[tokio::test]
+async fn test_cr_then_non_lf_across_chunks() {
+    // Original: "data: a\rdata: b\n\n"  =>  one event with "a\nb"
+    let out = collect_from_chunks(vec![b"data: a\r", b"data: b\n\n"]).await;
+    assert_eq!(out, vec![data_only("a\nb")]);
+}
+
+/// Trailing `\r` followed by another `\r` across chunks should produce
+/// two distinct line terminators (and thus an empty-line dispatch in between).
+#[tokio::test]
+async fn test_cr_then_cr_across_chunks() {
+    // Original: "data: a\r\rdata: b\n\n" -> ["data: a", "", "data: b", ""]
+    // -> dispatch event {data:"a"} on the second "", then "data: b" continues a new event
+    let out = collect_from_chunks(vec![b"data: a\r", b"\rdata: b\n\n"]).await;
+    assert_eq!(out, vec![data_only("a"), data_only("b")]);
+}
+
+/// Pathological: every byte arrives in its own chunk.
+#[tokio::test]
+async fn test_one_byte_per_chunk() {
+    let payload: &[u8] = b"data: hi\r\n\r\n";
+    let chunks: Vec<&'static [u8]> = vec![
+        b"d", b"a", b"t", b"a", b":", b" ", b"h", b"i", b"\r", b"\n", b"\r", b"\n",
+    ];
+    // sanity check
+    let joined: Vec<u8> = chunks.iter().flat_map(|c| c.iter().copied()).collect();
+    assert_eq!(joined, payload);
+
+    let out = collect_from_chunks(chunks).await;
+    assert_eq!(out, vec![data_only("hi")]);
+}
+
+/// The dispatch boundary (the empty line) is split exactly at the `\r`.
+#[tokio::test]
+async fn test_dispatch_boundary_split_at_cr() {
+    // "data: x\r\n\r\n" split as "data: x\r\n\r" + "\n"
+    // Expected: one event {data: "x"}.
+    let out = collect_from_chunks(vec![b"data: x\r\n\r", b"\n"]).await;
+    assert_eq!(out, vec![data_only("x")]);
+}
+
+/// Multiple consecutive `\r`s should produce multiple line terminators.
+#[tokio::test]
+async fn test_multiple_consecutive_cr() {
+    // "data: a\r\r\r" -> lines: "data: a", "", ""  -> dispatch after first empty.
+    let out = collect_from_full(b"data: a\r\r\r").await;
+    assert_eq!(out, vec![data_only("a")]);
+}
+
+// =====================================================================
+// BOM handling combined with `\r` line breaks
+// =====================================================================
+
+#[tokio::test]
+async fn test_bom_with_cr_line_breaks() {
+    let out = collect_from_full(b"\xEF\xBB\xBFdata: hello\r\r").await;
+    assert_eq!(out, vec![data_only("hello")]);
+}
+
+#[tokio::test]
+async fn test_bom_split_then_cr_split() {
+    // BOM split, AND the trailing `\r\n` split across chunks.
+    let out = collect_from_chunks(vec![
+        b"\xEF\xBB",
+        b"\xBFdata: hello\r",
+        b"\n\r\n",
+    ])
+    .await;
+    assert_eq!(out, vec![data_only("hello")]);
+}
+
+// =====================================================================
+// Field parsing corner cases (post-fix: relaxed semantics)
+// =====================================================================
+
+/// Per the SSE spec, a line with no `:` is treated as a field name with
+/// empty value. The fix changed this from an error to a silent ignore
+/// (since none of the recognised fields can have an empty name).
+#[tokio::test]
+async fn test_line_without_colon_is_ignored() {
+    let out = collect_from_full(b"foobar\ndata: hi\n\n").await;
+    assert_eq!(out, vec![data_only("hi")]);
+}
+
+/// Comment lines (starting with `:`) must be ignored but must NOT break dispatch.
+#[tokio::test]
+async fn test_comment_lines() {
+    let out = collect_from_full(b": this is a comment\ndata: hi\n: another\n\n").await;
+    assert_eq!(out, vec![data_only("hi")]);
+}
+
+/// `data:` with no value should produce an empty data string.
+#[tokio::test]
+async fn test_empty_data_field() {
+    let out = collect_from_full(b"data:\n\n").await;
+    assert_eq!(out, vec![data_only("")]);
+}
+
+/// `data: ` -> only the single leading space stripped, value is empty.
+/// Two consecutive `data:` lines produce a single `\n`.
+#[tokio::test]
+async fn test_two_empty_data_lines_join_with_newline() {
+    let out = collect_from_full(b"data:\ndata:\n\n").await;
+    assert_eq!(out, vec![data_only("\n")]);
+}
+
+/// Only a single leading space is stripped from field values.
+#[tokio::test]
+async fn test_only_one_leading_space_stripped() {
+    let out = collect_from_full(b"data:  hello\n\n").await;
+    // The first space is stripped, the second is preserved.
+    assert_eq!(out, vec![data_only(" hello")]);
+}
+
+/// Duplicated `event`/`id` lines should now overwrite (not error).
+#[tokio::test]
+async fn test_duplicated_event_overwrites() {
+    let out = collect_from_full(b"event: first\nevent: second\ndata: x\n\n").await;
+    assert_eq!(
+        out,
+        vec![Sse {
+            event: Some("second".into()),
+            data: Some("x".into()),
+            id: None,
+            retry: None,
+        }]
+    );
+}
+
+#[tokio::test]
+async fn test_duplicated_id_overwrites() {
+    let out = collect_from_full(b"id: a\nid: b\ndata: x\n\n").await;
+    assert_eq!(
+        out,
+        vec![Sse {
+            event: None,
+            data: Some("x".into()),
+            id: Some("b".into()),
+            retry: None,
+        }]
+    );
+}
+
+/// Invalid `retry:` value (non-int) should be silently ignored, not error.
+#[tokio::test]
+async fn test_invalid_retry_ignored() {
+    let out = collect_from_full(b"retry: not-a-number\ndata: x\n\n").await;
+    assert_eq!(out, vec![data_only("x")]);
+}
+
+/// Unknown fields should be ignored, not error.
+#[tokio::test]
+async fn test_unknown_field_ignored() {
+    let out = collect_from_full(b"weird: field\ndata: x\n\n").await;
+    assert_eq!(out, vec![data_only("x")]);
+}
+
+/// Stream that ends without a terminating empty line: the trailing
+/// incomplete event MUST be discarded (per the post-fix `None` branch).
+#[tokio::test]
+async fn test_incomplete_trailing_event_discarded() {
+    // No empty line after the second event.
+    let out = collect_from_full(b"data: complete\n\ndata: incomplete\n").await;
+    assert_eq!(out, vec![data_only("complete")]);
+}
+
+/// Single-event payload split right inside a UTF-8 multi-byte character
+/// inside the data field (across chunks). Buffering must keep it intact.
+#[tokio::test]
+async fn test_multibyte_split_across_chunks() {
+    // "中" is 0xE4 0xB8 0xAD in UTF-8.
+    let out = collect_from_chunks(vec![b"data: \xE4", b"\xB8\xAD\n\n"]).await;
+    assert_eq!(out, vec![data_only("中")]);
+}
+
+/// Multiple complete events split awkwardly across chunks.
+#[tokio::test]
+async fn test_multiple_events_split_chunks() {
+    let out = collect_from_chunks(vec![
+        b"event: a\ndata: 1\n",
+        b"\nevent: b\nda",
+        b"ta: 2\n\n",
+    ])
+    .await;
+    assert_eq!(
+        out,
+        vec![
+            Sse {
+                event: Some("a".into()),
+                data: Some("1".into()),
+                ..Default::default()
+            },
+            Sse {
+                event: Some("b".into()),
+                data: Some("2".into()),
+                ..Default::default()
+            },
+        ]
+    );
 }
 
 #[tokio::test]

--- a/tests/test_bytes_parse.rs
+++ b/tests/test_bytes_parse.rs
@@ -35,8 +35,10 @@ impl http_body::Body for ChainedFrameBody {
             return std::task::Poll::Ready(None);
         }
         self.sent = true;
-        let chained =
-            bytes::Buf::chain(Bytes::from_static(self.first), Bytes::from_static(self.second));
+        let chained = bytes::Buf::chain(
+            Bytes::from_static(self.first),
+            Bytes::from_static(self.second),
+        );
         std::task::Poll::Ready(Some(Ok(Frame::data(chained))))
     }
 }
@@ -236,27 +238,13 @@ async fn test_bom_with_cr_line_breaks() {
 #[tokio::test]
 async fn test_bom_split_then_cr_split() {
     // BOM split, AND the trailing `\r\n` split across chunks.
-    let out = collect_from_chunks(vec![
-        b"\xEF\xBB",
-        b"\xBFdata: hello\r",
-        b"\n\r\n",
-    ])
-    .await;
+    let out = collect_from_chunks(vec![b"\xEF\xBB", b"\xBFdata: hello\r", b"\n\r\n"]).await;
     assert_eq!(out, vec![data_only("hello")]);
 }
 
 // =====================================================================
-// Field parsing corner cases (post-fix: relaxed semantics)
+// Field parsing corner cases
 // =====================================================================
-
-/// Per the SSE spec, a line with no `:` is treated as a field name with
-/// empty value. The fix changed this from an error to a silent ignore
-/// (since none of the recognised fields can have an empty name).
-#[tokio::test]
-async fn test_line_without_colon_is_ignored() {
-    let out = collect_from_full(b"foobar\ndata: hi\n\n").await;
-    assert_eq!(out, vec![data_only("hi")]);
-}
 
 /// Comment lines (starting with `:`) must be ignored but must NOT break dispatch.
 #[tokio::test]
@@ -288,51 +276,25 @@ async fn test_only_one_leading_space_stripped() {
     assert_eq!(out, vec![data_only(" hello")]);
 }
 
-/// Duplicated `event`/`id` lines should now overwrite (not error).
+/// Per spec: an `id` field whose value contains U+0000 NULL must be ignored
+/// entirely (the rest of the event is still dispatched).
 #[tokio::test]
-async fn test_duplicated_event_overwrites() {
-    let out = collect_from_full(b"event: first\nevent: second\ndata: x\n\n").await;
-    assert_eq!(
-        out,
-        vec![Sse {
-            event: Some("second".into()),
-            data: Some("x".into()),
-            id: None,
-            retry: None,
-        }]
-    );
-}
-
-#[tokio::test]
-async fn test_duplicated_id_overwrites() {
-    let out = collect_from_full(b"id: a\nid: b\ndata: x\n\n").await;
-    assert_eq!(
-        out,
-        vec![Sse {
-            event: None,
-            data: Some("x".into()),
-            id: Some("b".into()),
-            retry: None,
-        }]
-    );
-}
-
-/// Invalid `retry:` value (non-int) should be silently ignored, not error.
-#[tokio::test]
-async fn test_invalid_retry_ignored() {
-    let out = collect_from_full(b"retry: not-a-number\ndata: x\n\n").await;
-    assert_eq!(out, vec![data_only("x")]);
-}
-
-/// Unknown fields should be ignored, not error.
-#[tokio::test]
-async fn test_unknown_field_ignored() {
-    let out = collect_from_full(b"weird: field\ndata: x\n\n").await;
-    assert_eq!(out, vec![data_only("x")]);
+async fn test_id_with_null_byte_ignored() {
+    let payload: &[u8] = b"id: ab\x00cd\ndata: x\n\n";
+    let stream = futures_util::stream::iter(std::iter::once(Ok::<_, std::convert::Infallible>(
+        Frame::data(Bytes::from_static(payload)),
+    )));
+    let body = StreamBody::new(stream);
+    let mut sse_body = SseStream::new(body);
+    let mut out = Vec::new();
+    while let Some(sse) = sse_body.next().await {
+        out.push(sse.expect("parse error"));
+    }
+    assert_eq!(out, vec![data_only("x")], "id with NULL must be ignored");
 }
 
 /// Stream that ends without a terminating empty line: the trailing
-/// incomplete event MUST be discarded (per the post-fix `None` branch).
+/// incomplete event MUST be discarded.
 #[tokio::test]
 async fn test_incomplete_trailing_event_discarded() {
     // No empty line after the second event.

--- a/tests/test_bytes_parse.rs
+++ b/tests/test_bytes_parse.rs
@@ -2,6 +2,30 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use http_body::Frame;
 use http_body_util::{Full, StreamBody};
+use sse_stream::{Sse, SseStream};
+
+async fn collect_from_full(data: &[u8]) -> Vec<Sse> {
+    let body = Full::<Bytes>::from(data.to_vec());
+    let mut sse_body = SseStream::new(body);
+    let mut out = Vec::new();
+    while let Some(sse) = sse_body.next().await {
+        out.push(sse.expect("parse error"));
+    }
+    out
+}
+
+async fn collect_from_chunks(chunks: Vec<&'static [u8]>) -> Vec<Sse> {
+    let stream = futures_util::stream::iter(chunks.into_iter().map(|c| {
+        Ok::<_, std::convert::Infallible>(Frame::data(Bytes::from_static(c)))
+    }));
+    let body = StreamBody::new(stream);
+    let mut sse_body = SseStream::new(body);
+    let mut out = Vec::new();
+    while let Some(sse) = sse_body.next().await {
+        out.push(sse.expect("parse error"));
+    }
+    out
+}
 
 #[tokio::test]
 async fn test_bytes_parse() {

--- a/tests/test_bytes_parse.rs
+++ b/tests/test_bytes_parse.rs
@@ -4,6 +4,70 @@ use http_body::Frame;
 use http_body_util::{Full, StreamBody};
 use sse_stream::{Sse, SseStream};
 
+// =====================================================================
+// Bug exposure: `Buf::chunk()` only returns the *first contiguous* slice.
+//
+// `SseStream` reads each frame via `data.chunk()`. The `Buf` contract,
+// however, only requires `chunk()` to return *some* prefix of the
+// remaining bytes — not all of them. For multi-segment `Buf`
+// implementations (e.g. the result of `Bytes::chain`), this silently
+// drops every byte after the first segment.
+// =====================================================================
+
+/// A body that emits a single frame whose `Data` is a multi-segment
+/// `Buf` (`bytes::buf::Chain`). `chunk()` on such a value returns only
+/// the first segment, so any naive `data.chunk()` reader will lose data.
+struct ChainedFrameBody {
+    sent: bool,
+    first: &'static [u8],
+    second: &'static [u8],
+}
+
+impl http_body::Body for ChainedFrameBody {
+    type Data = bytes::buf::Chain<Bytes, Bytes>;
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if self.sent {
+            return std::task::Poll::Ready(None);
+        }
+        self.sent = true;
+        let chained =
+            bytes::Buf::chain(Bytes::from_static(self.first), Bytes::from_static(self.second));
+        std::task::Poll::Ready(Some(Ok(Frame::data(chained))))
+    }
+}
+
+#[tokio::test]
+async fn test_multi_segment_buf_frame_not_truncated() {
+    // The full frame, once flattened, is a single complete SSE event.
+    // If `chunk()` is used naively, only the first segment ("data: hel")
+    // is read and the message is silently dropped at end-of-stream.
+    let body = ChainedFrameBody {
+        sent: false,
+        first: b"data: hel",
+        second: b"lo\n\n",
+    };
+    let mut sse_body = SseStream::new(body);
+    let mut out = Vec::new();
+    while let Some(sse) = sse_body.next().await {
+        out.push(sse.expect("parse error"));
+    }
+    assert_eq!(
+        out,
+        vec![Sse {
+            event: None,
+            data: Some("hello".into()),
+            id: None,
+            retry: None,
+        }],
+        "multi-segment Buf frame must be fully consumed"
+    );
+}
+
 async fn collect_from_full(data: &[u8]) -> Vec<Sse> {
     let body = Full::<Bytes>::from(data.to_vec());
     let mut sse_body = SseStream::new(body);

--- a/tests/test_bytes_parse.rs
+++ b/tests/test_bytes_parse.rs
@@ -129,32 +129,18 @@ async fn test_bom_header_at_start() {
     assert_eq!(sse.data, Some("hello".to_string()));
 }
 
-// =====================================================================
-// Line-break handling corner cases
-// =====================================================================
-
-/// `\n` line break only.
-#[tokio::test]
-async fn test_line_break_lf_only() {
-    let out = collect_from_full(b"data: a\ndata: b\n\n").await;
-    assert_eq!(out, vec![data_only("a\nb")]);
-}
-
-/// `\r\n` line break (Windows-style).
 #[tokio::test]
 async fn test_line_break_crlf() {
     let out = collect_from_full(b"data: a\r\ndata: b\r\n\r\n").await;
     assert_eq!(out, vec![data_only("a\nb")]);
 }
 
-/// Bare `\r` line break (legacy Mac style).
 #[tokio::test]
 async fn test_line_break_cr_only() {
     let out = collect_from_full(b"data: a\rdata: b\r\r").await;
     assert_eq!(out, vec![data_only("a\nb")]);
 }
 
-/// Mixed line breaks within the same payload.
 #[tokio::test]
 async fn test_line_break_mixed() {
     // `\n`, `\r`, and `\r\n` interleaved.
@@ -163,9 +149,6 @@ async fn test_line_break_mixed() {
     assert_eq!(out, vec![data_only("one\ntwo\nthree")]);
 }
 
-/// `\r` at the END of one chunk and `\n` at the START of the next chunk
-/// must be treated as ONE `\r\n` line break, not two empty separator lines.
-/// This is the central bug `MayTrailingNewline` is meant to fix.
 #[tokio::test]
 async fn test_cr_lf_split_across_chunks() {
     // Original payload:  "data: hello\r\ndata: world\n\n"
@@ -174,8 +157,6 @@ async fn test_cr_lf_split_across_chunks() {
     assert_eq!(out, vec![data_only("hello\nworld")]);
 }
 
-/// Trailing `\r` followed by a non-`\n` char in the next chunk should
-/// produce TWO line breaks (the `\r` alone, then a fresh line).
 #[tokio::test]
 async fn test_cr_then_non_lf_across_chunks() {
     // Original: "data: a\rdata: b\n\n"  =>  one event with "a\nb"
@@ -183,8 +164,6 @@ async fn test_cr_then_non_lf_across_chunks() {
     assert_eq!(out, vec![data_only("a\nb")]);
 }
 
-/// Trailing `\r` followed by another `\r` across chunks should produce
-/// two distinct line terminators (and thus an empty-line dispatch in between).
 #[tokio::test]
 async fn test_cr_then_cr_across_chunks() {
     // Original: "data: a\r\rdata: b\n\n" -> ["data: a", "", "data: b", ""]
@@ -193,22 +172,6 @@ async fn test_cr_then_cr_across_chunks() {
     assert_eq!(out, vec![data_only("a"), data_only("b")]);
 }
 
-/// Pathological: every byte arrives in its own chunk.
-#[tokio::test]
-async fn test_one_byte_per_chunk() {
-    let payload: &[u8] = b"data: hi\r\n\r\n";
-    let chunks: Vec<&'static [u8]> = vec![
-        b"d", b"a", b"t", b"a", b":", b" ", b"h", b"i", b"\r", b"\n", b"\r", b"\n",
-    ];
-    // sanity check
-    let joined: Vec<u8> = chunks.iter().flat_map(|c| c.iter().copied()).collect();
-    assert_eq!(joined, payload);
-
-    let out = collect_from_chunks(chunks).await;
-    assert_eq!(out, vec![data_only("hi")]);
-}
-
-/// The dispatch boundary (the empty line) is split exactly at the `\r`.
 #[tokio::test]
 async fn test_dispatch_boundary_split_at_cr() {
     // "data: x\r\n\r\n" split as "data: x\r\n\r" + "\n"
@@ -217,7 +180,6 @@ async fn test_dispatch_boundary_split_at_cr() {
     assert_eq!(out, vec![data_only("x")]);
 }
 
-/// Multiple consecutive `\r`s should produce multiple line terminators.
 #[tokio::test]
 async fn test_multiple_consecutive_cr() {
     // "data: a\r\r\r" -> lines: "data: a", "", ""  -> dispatch after first empty.
@@ -225,50 +187,24 @@ async fn test_multiple_consecutive_cr() {
     assert_eq!(out, vec![data_only("a")]);
 }
 
-// =====================================================================
-// BOM handling combined with `\r` line breaks
-// =====================================================================
-
-#[tokio::test]
-async fn test_bom_with_cr_line_breaks() {
-    let out = collect_from_full(b"\xEF\xBB\xBFdata: hello\r\r").await;
-    assert_eq!(out, vec![data_only("hello")]);
-}
-
-#[tokio::test]
-async fn test_bom_split_then_cr_split() {
-    // BOM split, AND the trailing `\r\n` split across chunks.
-    let out = collect_from_chunks(vec![b"\xEF\xBB", b"\xBFdata: hello\r", b"\n\r\n"]).await;
-    assert_eq!(out, vec![data_only("hello")]);
-}
-
-// =====================================================================
-// Field parsing corner cases
-// =====================================================================
-
-/// Comment lines (starting with `:`) must be ignored but must NOT break dispatch.
 #[tokio::test]
 async fn test_comment_lines() {
     let out = collect_from_full(b": this is a comment\ndata: hi\n: another\n\n").await;
     assert_eq!(out, vec![data_only("hi")]);
 }
 
-/// `data:` with no value should produce an empty data string.
 #[tokio::test]
 async fn test_empty_data_field() {
     let out = collect_from_full(b"data:\n\n").await;
     assert_eq!(out, vec![data_only("")]);
 }
 
-/// `data: ` -> only the single leading space stripped, value is empty.
-/// Two consecutive `data:` lines produce a single `\n`.
 #[tokio::test]
 async fn test_two_empty_data_lines_join_with_newline() {
     let out = collect_from_full(b"data:\ndata:\n\n").await;
     assert_eq!(out, vec![data_only("\n")]);
 }
 
-/// Only a single leading space is stripped from field values.
 #[tokio::test]
 async fn test_only_one_leading_space_stripped() {
     let out = collect_from_full(b"data:  hello\n\n").await;
@@ -276,8 +212,6 @@ async fn test_only_one_leading_space_stripped() {
     assert_eq!(out, vec![data_only(" hello")]);
 }
 
-/// Per spec: an `id` field whose value contains U+0000 NULL must be ignored
-/// entirely (the rest of the event is still dispatched).
 #[tokio::test]
 async fn test_id_with_null_byte_ignored() {
     let payload: &[u8] = b"id: ab\x00cd\ndata: x\n\n";
@@ -293,8 +227,6 @@ async fn test_id_with_null_byte_ignored() {
     assert_eq!(out, vec![data_only("x")], "id with NULL must be ignored");
 }
 
-/// Stream that ends without a terminating empty line: the trailing
-/// incomplete event MUST be discarded.
 #[tokio::test]
 async fn test_incomplete_trailing_event_discarded() {
     // No empty line after the second event.
@@ -302,16 +234,6 @@ async fn test_incomplete_trailing_event_discarded() {
     assert_eq!(out, vec![data_only("complete")]);
 }
 
-/// Single-event payload split right inside a UTF-8 multi-byte character
-/// inside the data field (across chunks). Buffering must keep it intact.
-#[tokio::test]
-async fn test_multibyte_split_across_chunks() {
-    // "中" is 0xE4 0xB8 0xAD in UTF-8.
-    let out = collect_from_chunks(vec![b"data: \xE4", b"\xB8\xAD\n\n"]).await;
-    assert_eq!(out, vec![data_only("中")]);
-}
-
-/// Multiple complete events split awkwardly across chunks.
 #[tokio::test]
 async fn test_multiple_events_split_chunks() {
     let out = collect_from_chunks(vec![


### PR DESCRIPTION
### Summary

This PR fixes several bugs and modifies some parsing logic to better align with the [HTML Server-Sent Events specification](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream). These changes include:

- Accepting non-contiguous implementations of `Buf` for `Body::Data`.
- Correctly parsing `\r` sequences that are split across chunks.
- Discarding incomplete events if the stream ends without a final empty line, as required by the SSE standard.
- Ignoring the `id` field if it contains a U+0000 NULL byte.

In order to maximize compatibility, this pull request intentionally does not implement certain other standard behaviors at this time, such as *ignoring events without data, inheriting the last event-id, etc*.

Note: Some test cases were generated by Opus 4.7, but the core logic changes were manually written and reviewed by myself.